### PR TITLE
Fix magic harp vs shopkeeper bug

### DIFF
--- a/src/dog.c
+++ b/src/dog.c
@@ -887,6 +887,11 @@ register struct obj *obj;
 	if (is_mriding(mtmp) || is_mridden(mtmp))
 	    return((struct monst *)0);
 #endif
+	if (mtmp->isshk && !obj) {
+	    make_happy_shk(mtmp, FALSE);
+	    return((struct monst *)0);
+	}
+
 	/* worst case, at least it'll be peaceful. */
 	setmpeaceful(mtmp, TRUE);
 

--- a/src/read.c
+++ b/src/read.c
@@ -767,9 +767,7 @@ struct obj *sobj;
 	if (sobj->cursed) {
 	    setmangry(mtmp);
 	} else {
-	    if (mtmp->isshk)
-		make_happy_shk(mtmp, FALSE);
-	    else if (!resist(mtmp, sobj->oclass, 0, NOTELL))
+	    if (!resist(mtmp, sobj->oclass, 0, NOTELL))
 		(void) tamedog(mtmp, (struct obj *) 0);
 	}
 }


### PR DESCRIPTION
店外から飛び道具で店主を攻撃し、魔法の竪琴で店主をなだめると、店主がおかしな状態になるバグを修正