### PR TITLE
Allow variety of japanese gauntlets words

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -2308,6 +2308,9 @@ boolean from_user;
 #ifdef JP
 	/* ˆê•”‚Ì‘SŠp•¶š‚ğ”¼Šp‚É•ÏŠ·‚µ‚Ä‚¨‚­ */
 	ztoh(bp);
+	/* ‚±‚Ä‘Îô */
+	if (!strcmpr(bp, "¬è") || !strcmpr(bp, "âÄè"))
+	    strcpy(eos(bp) - 4, "˜Uè");
 #endif /*JP*/
 
 	/* allow wishing for "nothing" to preserve wishless conduct...


### PR DESCRIPTION
日本語での願いで「小手」「籠手」を「篭手」のバリエーションとして許すようにした