### PR TITLE
Modify worn out gear handling

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2630,6 +2630,7 @@ E int FDECL(bresenham_step, (struct bresenham *));
 E void FDECL(bresenham_back, (struct bresenham *));
 E void FDECL(setup_zapinfo, (struct zapinfo *, uchar, uchar, uchar, uchar, const char *, const char *, BOOLEAN_P));
 E void FDECL(setup_zapobj, (struct zapinfo *, struct obj *, boolean));
+E boolean FDECL(does_obj_worn_out, (struct obj *));
 
 #endif /* !MAKEDEFS_C && !LEV_LEX_C */
 

--- a/include/obj.h
+++ b/include/obj.h
@@ -103,7 +103,8 @@ struct obj {
 #define leashmon  corpsenm	/* gets m_id of attached pet */
 #define spestudied corpsenm	/* # of times a spellbook has been studied */
 #define fromsink  corpsenm	/* a potion from a sink */
-				/* hawaiian shirt and T-shirt uses corpsenm as its color */
+#define prevotyp  corpsenm	/* previous otyp (plain dragon scale mail) */
+
 	unsigned oeaten;	/* nutrition left in food, if partly eaten */
 #define odamaged oeaten		/* how much object's special power worn out */
 	long age;		/* creation date */

--- a/src/potion.c
+++ b/src/potion.c
@@ -2111,6 +2111,41 @@ dodip()
 	    }
 	}
 
+	if (potion->otyp == POT_GAIN_ENERGY &&
+	    does_obj_worn_out(obj)) {
+	    int change_otyp = 0;
+	    boolean isworn = FALSE;
+	    /* recover the magical power */
+	    if ((obj->otyp == SHIELD && get_material(obj) == SILVER) ||
+		obj->otyp == PLAIN_DRAGON_SCALE_MAIL) {
+		obj->odamaged = 1;
+		change_otyp = obj->prevotyp;
+		if (obj->otyp == SHIELD && obj == uarms) {
+		    Shield_off();
+		    isworn = TRUE;
+		}
+		if (obj->otyp == PLAIN_DRAGON_SCALE_MAIL && obj == uarm) {
+		    Armor_off();
+		    isworn = TRUE;
+		}
+	    }
+	    if (obj->odamaged > 0) {
+#ifndef JP
+		You_feel("%s regains its magical power!", yname(obj))
+#else
+		You("%s���Ăі��@�̗͂���߂��̂�������I", xname(obj));
+#endif /*JP*/
+		obj->odamaged = 0;
+		if (change_otyp) {
+		    change_material(obj, 0);
+		    set_otyp(obj, obj->prevotyp);
+		    if (isworn) quickdowear(obj);
+		    prinv((char *)0, obj, 0L);
+		}
+		goto poof;
+	    }
+	}
+
 	if (potion->otyp == POT_OIL) {
 	    boolean wisx = FALSE;
 	    if (potion->lamplit) {	/* burning */

--- a/src/zap.c
+++ b/src/zap.c
@@ -5228,7 +5228,6 @@ int damval;
 			if ((*(tbl->objp))->oartifact) return;
 			oc1 = tbl->objclass;
 			oc2 = tbl->objsubc;
-			break;
 		}
 	}
 	if ( !oc1 ) return;	/* there is no object to get damaged */
@@ -5302,6 +5301,7 @@ int damval;
 							  "Ž©•ª‚Ì‚‚ª‚È‚ñ‚Æ‚È‚­—Š‚è‚È‚­‚È‚Á‚½‚Ì‚ðŠ´‚¶‚½B"));
 					otmp = uarms;
 					Shield_off();
+					otmp->prevotyp = otmp->otyp;
 					set_otyp(otmp, SHIELD);
 					otmp->odamaged = 0;
 					change_material(otmp, SILVER);	/* mere silver shield */
@@ -5339,6 +5339,7 @@ int damval;
 						 "%s‚Í—Í‚ðŽ¸‚Á‚½‚æ‚¤‚¾B"), buf);
 					otmp = uarm;
 					Armor_off();
+					otmp->prevotyp = otmp->otyp;
 					set_otyp(otmp, PLAIN_DRAGON_SCALE_MAIL);	/* mere scale mail */
 					otmp->odamaged = 0;
 					setworn(otmp, W_ARM);
@@ -5376,5 +5377,24 @@ int damval;
 	return;
 }
 
+boolean 
+does_obj_worn_out(otmp)
+struct obj *otmp;
+{
+	if (otmp->oartifact) return FALSE;
+	if (otmp->otyp == AMULET_OF_REFLECTION ||
+	    otmp->otyp == SHIELD_OF_REFLECTION ||
+	    otmp->otyp == CLOAK_OF_MAGIC_RESISTANCE ||
+	    otmp->otyp == FRILLED_APRON ||
+	    otmp->otyp == SILVER_DRAGON_SCALE_MAIL ||
+	    otmp->otyp == SILVER_DRAGON_SCALES ||
+	    otmp->otyp == GRAY_DRAGON_SCALE_MAIL ||
+	    otmp->otyp == GRAY_DRAGON_SCALES ||
+	    otmp->otyp == PLAIN_DRAGON_SCALE_MAIL)
+		return TRUE;
+	if (otmp->otyp == SHIELD && get_material(otmp) == SILVER)
+		return TRUE;
+	return FALSE;
+}
 
 /*zap.c*/


### PR DESCRIPTION
・反射・魔法防御の特性を持つ装備は効果を発揮するたびに劣化して最終的には使えなくなるが、魔力の薬に浸けることで効果を回復するようにした。（魔除けやクロークは破壊される前に回復させる必要がある）
・反射装備を複数装備しているときに劣化する装備が間違っていたバグを修正