### PR TITLE
Grave and pit improvement

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,8 @@
 *.dat diff=sjis
 *.des diff=sjis
 *.txt diff=sjis
+*.c text eol=lf
+*.h text eol=lf
+*.dat text eol=lf
+*.des text eol=lf
+*.txt text eol=lf

--- a/include/extern.h
+++ b/include/extern.h
@@ -625,6 +625,7 @@ E void FDECL(rest_engravings, (int));
 E void FDECL(del_engr, (struct engr *));
 E void FDECL(rloc_engr, (struct engr *));
 E void FDECL(make_grave, (int,int,const char *));
+E void FDECL(dispose_grave, (int,int));
 E void FDECL(read_wallsign_at, (int,int));
 E void FDECL(make_wallsign_at, (int,int,int,int,const char *,XCHAR_P));
 E void NDECL(remember_wallsign_on);
@@ -1070,7 +1071,7 @@ E int FDECL(doseduce, (struct monst *));
 #endif
 E boolean FDECL(is_full_resist, (uchar));
 E int FDECL(reduce_dmg_amount, (struct obj *));
-E int FDECL(reduce_damage, (int, int));
+E int FDECL(reduce_damage, (int));
 E void FDECL(hurtarmor,(int));
 E int FDECL(parry_with_shield, (struct monst *,struct monst *,struct attack *));
 

--- a/include/rm.h
+++ b/include/rm.h
@@ -380,6 +380,16 @@ extern const struct symdef def_warnsyms[WARNCOUNT];
 #define ICED_MOAT	16
 
 /*
+ * Where is a grave standing on
+ */
+#define GRV_ROOM	0x00
+#define GRV_CORR	0x01
+#define GRV_ICE		0x02
+#define GRV_GROUND	0x03
+#define GRV_MASK	0x03	/* mask for base */
+#define GRV_BONES	0x04
+
+/*
  * The structure describing a coordinate position.
  * Before adding fields, remember that this will significantly affect
  * the size of temporary files and save files.
@@ -488,6 +498,7 @@ struct rm {
 #define drawbridgemask	flags
 #define looted		flags
 #define icedpool	flags
+#define gravemask	flags
 
 #define blessedftn	horizontal  /* a fountain that grants attribs */
 #define disturbed	horizontal  /* a grave that has been disturbed */

--- a/src/apply.c
+++ b/src/apply.c
@@ -1682,7 +1682,7 @@ int magic; /* 0=Physical, otherwise skill level */
 		    break;
 		  }
 		case TT_PIT:
-		    You(E_J("leap from the pit!","落し穴から跳びあがった！"));
+		    You(E_J("leap from the pit!","落とし穴から跳びあがった！"));
 		    break;
 		case TT_WEB:
 		    You(E_J("tear the web apart as you pull yourself free!",
@@ -2957,7 +2957,7 @@ struct obj *obj;
 	    if (proficient && rn2(proficient + 2)) {
 		if (!mtmp || enexto(&cc, rx, ry, youmonst.data)) {
 		    You(E_J("yank yourself out of the pit!",
-			    "自分を落し穴から引き上げた！"));
+			    "自分を落とし穴から引き上げた！"));
 		    teleds(cc.x, cc.y, TRUE);
 		    u.utrap = 0;
 		    vision_full_recalc = 1;

--- a/src/ball.c
+++ b/src/ball.c
@@ -669,7 +669,7 @@ xchar x, y;
 	if (u.utrap && u.utraptype != TT_INFLOOR) {
 	    switch(u.utraptype) {
 	    case TT_PIT:
-		pline(pullmsg, E_J("pit","—‚µŒŠ"));
+		pline(pullmsg, E_J("pit","—‚Æ‚µŒŠ"));
 		break;
 	    case TT_WEB:
 		pline(pullmsg, E_J("web","’wå‚Ì‘ƒ"));

--- a/src/do.c
+++ b/src/do.c
@@ -194,7 +194,7 @@ const char *verb;
 				vtense((const char *)0, verb),
 				(mtmp) ? "" : " with you");
 #else
-			pline("‘åŠâ‚Í%s—Ž‚µŒŠ‚É%sB",
+			pline("‘åŠâ‚Í%s—Ž‚Æ‚µŒŠ‚É%sB",
 				(mtmp) ? "" : "‚ ‚È‚½‚Æ‚Æ‚à‚É", verb);
 #endif /*JP*/
 		    if (mtmp) {
@@ -229,7 +229,7 @@ const char *verb;
 				    t->tseen ? "" : "‰B‚³‚ê‚½ã©‚É“Ë‚Áž‚ÝA",
 				    t->ttyp == TRAPDOOR ? "—Ž‚Æ‚µ”à‚ð‚Ó‚³‚¢‚¾" :
 				    t->ttyp == HOLE ? "ŒŠ‚ð‚Ó‚³‚¢‚¾" :
-				    "—Ž‚µŒŠ‚ð–„‚ß‚½");
+				    "—Ž‚Æ‚µŒŠ‚ð–„‚ß‚½");
 #endif /*JP*/
 			} else
 				You_hear(E_J("the boulder %s.","‘åŠâ‚ª%s‰¹‚ð"), verb);
@@ -277,7 +277,7 @@ const char *verb;
 //				The(xname(obj)), otense(obj, "tumble"),
 //				the_your[t->madeby_u]);
 //#else
-//			pline("%s‚Í%s—Ž‚µŒŠ‚É“]‚ª‚è—Ž‚¿‚½B",
+//			pline("%s‚Í%s—Ž‚Æ‚µŒŠ‚É“]‚ª‚è—Ž‚¿‚½B",
 //				xname(obj), the_your[t->madeby_u]);
 //#endif /*JP*/
 	}
@@ -943,13 +943,20 @@ dodown()
 
 	if (trap) {
 	    if (trap->ttyp == PIT || trap->ttyp == SPIKED_PIT) {
-		You(E_J("carefully slide down into the %s",
-			"’ˆÓ[‚­%s‚Ì’†‚ÉŠŠ‚èž‚ñ‚¾B"),
-			defsyms[trap_to_defsym(trap->ttyp)].explanation );
-		u.utraptype = TT_PIT;
-		u.utrap = rn1(6,2);
-		vision_full_recalc = 1;	/* vision limits change */	/*[Sakusha]*/
-		return(0);
+		if (u.utrap == 0) {
+		    You(E_J("carefully slide down into the %s",
+			    "’ˆÓ[‚­%s‚Ì’†‚ÉŠŠ‚èž‚ñ‚¾B"),
+			    defsyms[trap_to_defsym(trap->ttyp)].explanation );
+		    u.utraptype = TT_PIT;
+		    u.utrap = rn1(6,2);
+		    vision_full_recalc = 1;	/* vision limits change */	/*[Sakusha]*/
+		    return(1);
+		} else {
+		    You(E_J("are already in the bottom of the %s",
+			    "‚·‚Å‚É%s‚Ì’ê‚É‚¢‚éB"),
+			    defsyms[trap_to_defsym(trap->ttyp)].explanation );
+		    return(0);
+		}
 	    } /*else*/
 #ifndef JP
 	    You("%s %s.", locomotion(youmonst.data, "jump"),

--- a/src/drawing.c
+++ b/src/drawing.c
@@ -312,8 +312,8 @@ const struct symdef defsyms[MAXPCHARS] = {
 /*50*/	{'^', EJ2("sleeping gas trap",	"睡眠ガスの罠"),   C(HI_ZAP)},		/* trap */
 	{'^', EJ2("rust trap",		"腐食の罠"),	   C(CLR_BLUE)},	/* trap */
 	{'^', EJ2("fire trap",		"炎の罠"),	   C(CLR_ORANGE)},	/* trap */
-	{'^', EJ2("pit",		"落し穴"),	   C(CLR_BLACK)},	/* trap */
-	{'^', EJ2("spiked pit",	"棘の仕掛けられた落し穴"), C(CLR_BLACK)},	/* trap */
+	{'^', EJ2("pit",		"落とし穴"),	   C(CLR_BLACK)},	/* trap */
+	{'^', EJ2("spiked pit",	"棘の仕掛けられた落とし穴"), C(CLR_BLACK)},	/* trap */
 	{'^', EJ2("hole",		"穴"),		   C(CLR_BROWN)},	/* trap */
 	{'^', EJ2("trap door",		"落とし扉"),	   C(CLR_BROWN)},	/* trap */
 	{'^', EJ2("teleportation trap",	"テレポートの罠"), C(CLR_MAGENTA)},	/* trap */

--- a/src/end.c
+++ b/src/end.c
@@ -878,6 +878,7 @@ die:
 		}
 #endif /*JP*/
 		make_grave(u.ux, u.uy, pbuf);
+		levl[u.ux][u.uy].gravemask |= GRV_BONES;
 	    }
 	}
 

--- a/src/engrave.c
+++ b/src/engrave.c
@@ -1477,17 +1477,68 @@ make_grave(x, y, str)
 int x, y;
 const char *str;
 {
+	int base;
+
 	/* Can we put a grave here? */
-	if ((levl[x][y].typ != ROOM && levl[x][y].typ != GRAVE) || t_at(x,y)) return;
+	if (t_at(x,y)) return;
+	switch (levl[x][y].typ) {
+	    case ROOM:
+	    case CARPET:
+		base = GRV_ROOM;
+		break;
+	    case CORR:
+		base = GRV_CORR;
+		break;
+	    case ICE:
+		base = GRV_ICE;
+		break;
+	    case GRASS:
+	    case GROUND:
+		base = GRV_GROUND;
+		break;
+	    default:
+		/* we can't */
+		return;
+	}
 
 	/* Make the grave */
 	levl[x][y].typ = GRAVE;
+	levl[x][y].gravemask = base;
+	levl[x][y].disturbed = 0;
 
 	/* Engrave the headstone */
 	if (!str) str = epitaphs[rn2(SIZE(epitaphs))];
 	del_engr_at(x, y);
 	make_engr_at(x, y, str, 0L, HEADSTONE);
 	return;
+}
+
+void
+dispose_grave(x, y)
+int x, y;
+{
+	if (levl[x][y].typ != GRAVE) return;
+
+	switch(levl[x][y].gravemask & GRV_MASK) {
+	    case GRV_ROOM:
+		levl[x][y].typ = ROOM;
+		break;
+	    case GRV_CORR:
+		levl[x][y].typ = CORR;
+		break;
+	    case GRV_ICE:
+		levl[x][y].typ = ICE;
+		break;
+	    case GRV_GROUND:
+		levl[x][y].typ = GROUND;
+		break;
+	    default:
+		levl[x][y].typ = ROOM;
+		break;
+	}
+	levl[x][y].gravemask = 0;
+	levl[x][y].disturbed = 0;
+	del_engr_at(x, y);
 }
 
 /* wall sign */

--- a/src/hack.c
+++ b/src/hack.c
@@ -2314,7 +2314,7 @@ dopickup()
 		if ((traphere->ttyp == PIT || traphere->ttyp == SPIKED_PIT) &&
 		     (!u.utrap || (u.utrap && u.utraptype != TT_PIT))) {
 			if (yn(E_J("You cannot pick up the object in the pit. Do you want to go down?",
-				   "ここからでは届かない。落し穴の底に降りますか？")) == 'y') {
+				   "ここからでは届かない。落とし穴の底に降りますか？")) == 'y') {
 			    You(E_J("carefully slide down into the %s",
 				    "注意深く%sの中に滑り込んだ。"),
 				    defsyms[trap_to_defsym(traphere->ttyp)].explanation);
@@ -2323,7 +2323,7 @@ dopickup()
 			    vision_full_recalc = 1;	/* vision limits change */	/*[Sakusha]*/
 			} else {
 			    You(E_J("cannot reach the bottom of the pit.",
-				    "落し穴の底まで届かない。"));
+				    "落とし穴の底まで届かない。"));
 			    return(0);
 			}
 		}

--- a/src/levitate.c
+++ b/src/levitate.c
@@ -42,7 +42,7 @@ float_up()
 		if(u.utraptype == TT_PIT) {
 			u.utrap = 0;
 			You(E_J("float up, out of the pit!",
-				"浮き上がり、落し穴から抜け出た！"));
+				"浮き上がり、落とし穴から抜け出た！"));
 			vision_full_recalc = 1;	/* vision limits change */
 			fill_pit(u.ux, u.uy);
 		} else if (u.utraptype == TT_INFLOOR) {

--- a/src/lock.c
+++ b/src/lock.c
@@ -439,7 +439,7 @@ pick_lock(pick) /* pick a lock with a given object */
 
 	    if (u.utrap && u.utraptype == TT_PIT) {
 		You_cant(E_J("reach over the edge of the pit.",
-			     "落し穴の中からは届かない。"));
+			     "落とし穴の中からは届かない。"));
 		return(0);
 	    }
 
@@ -637,7 +637,7 @@ doopen()		/* try to open a door */
 
 	if (u.utrap && u.utraptype == TT_PIT) {
 	    You_cant(E_J("reach over the edge of the pit.",
-			 "落し穴の中からは届かない。"));
+			 "落とし穴の中からは届かない。"));
 	    return 0;
 	}
 
@@ -776,7 +776,7 @@ doclose()		/* try to close a door */
 
 	if (u.utrap && u.utraptype == TT_PIT) {
 	    You_cant(E_J("reach over the edge of the pit.",
-			 "落し穴の中からは届かない。"));
+			 "落とし穴の中からは届かない。"));
 	    return 0;
 	}
 

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -186,7 +186,7 @@ const char *name;	/* if null, then format `obj' */
 				  "‚ ‚È‚½‚Í‚Â‚©‚È‚¢‚æ‚¤‚¾B"));
 		else {
 			if (is_acid) pline(E_J("It burns!","g‘Ì‚ªÜ‚¯‚éI"));
-			if (dam) dam = reduce_damage(dam, DAMCAN_RANDOM);
+			if (dam) dam = reduce_damage(dam);
 			if (Half_physical_damage) dam = (dam+1) / 2;
 			losehp(dam, knm, kprefix);
 			exercise(A_STR, FALSE);

--- a/src/trap.c
+++ b/src/trap.c
@@ -536,13 +536,12 @@ register int x, y, typ;
 		    add_damage(x, y,		/* schedule repair */
 			       ((IS_DOOR(lev->typ) || IS_WALL(lev->typ))
 				&& !flags.mon_moving) ? 200L : 0L);
-		lev->doormask = 0;	/* subsumes altarmask, icedpool... */
-		if (IS_FLOOR(lev->typ))
-		    /* nothing */;
-		else
-		if (IS_ROOM(lev->typ)) /* && !IS_AIR(lev->typ) */
-		    lev->typ = ROOM;
-
+		if (IS_GRAVE(lev->typ))
+			dispose_grave(x, y);
+		else if (IS_FLOOR(lev->typ))
+			/* nothing */;
+		else if (IS_ROOM(lev->typ)) /* && !IS_AIR(lev->typ) */
+			lev->typ = ROOM;
 		/*
 		 * some cases which can happen when digging
 		 * down while phazing thru solid areas
@@ -553,6 +552,7 @@ register int x, y, typ;
 		    lev->typ = level.flags.is_maze_lev ? ROOM :
 			       level.flags.is_cavernous_lev ? CORR : DOOR;
 
+		lev->doormask = 0;	/* subsumes altarmask, icedpool... */
 		unearth_objs(x, y);
 		break;
 	    case RUST_TRAP:
@@ -1337,13 +1337,13 @@ pitfall:
 #endif
 		if (ttype == SPIKED_PIT) {
 		    losehp(rnd(10),E_J("fell into a pit of iron spikes",
-				       "鉄の棘の仕掛けられた落し穴に落ちて"),
+				       "鉄の棘の仕掛けられた落とし穴に落ちて"),
 			E_J(NO_KILLER_PREFIX,KILLED_BY));
 		    if (!rn2(6))
 			poisoned(E_J("spikes","棘"), A_STR,
 				 E_J("fall onto poison spikes","毒を塗られた棘の上に落ちて死んだ"), 8);
 		} else
-		    losehp(rnd(6),E_J("fell into a pit","落し穴に落ちて"), E_J(NO_KILLER_PREFIX,KILLED_BY));
+		    losehp(rnd(6),E_J("fell into a pit","落とし穴に落ちて"), E_J(NO_KILLER_PREFIX,KILLED_BY));
 		if (Punished && !carried(uball)) {
 		    unplacebc();
 		    ballfall();
@@ -2550,7 +2550,7 @@ glovecheck:		    target = which_armor(mtmp, W_ARMG);
 				  Monnam(mtmp), fallverb,
 				  a_your[trap->madeby_u]);
 #else
-			    pline("%sは%s落し穴に%s！",
+			    pline("%sは%s落とし穴に%s！",
 				  Monnam(mtmp),
 				  trap->madeby_u ? "あなたが掘った" : "",
 				  fallverb);
@@ -4011,7 +4011,7 @@ struct trap *ttmp;
 			Sprintf(kbuf, "trying to help %s out of a pit",
 					an(mtmp->data->mname));
 #else
-			Sprintf(kbuf, "%sを落し穴から助けようとして",
+			Sprintf(kbuf, "%sを落とし穴から助けようとして",
 					JMONNAM(monsndx(mtmp->data)));
 #endif /*JP*/
 			instapetrify(kbuf);
@@ -4066,7 +4066,7 @@ struct trap *ttmp;
 	if (!try_lift(mtmp, ttmp, wt, TRUE)) return 1;
 
 	You(E_J("pull %s out of the pit.",
-		"%sを落し穴から引っぱり出した。"), mon_nam(mtmp));
+		"%sを落とし穴から引っぱり出した。"), mon_nam(mtmp));
 	mtmp->mtrapped = 0;
 	fill_pit(mtmp->mx, mtmp->my);
 	reward_untrap(ttmp, mtmp);
@@ -4116,8 +4116,8 @@ boolean force;
 #else
 			    You("%s何もできることはない。",
 				u.utrap ?
-				"自分のはまっている落し穴に対して" :
-				"落し穴の縁に立っている間は");
+				"自分のはまっている落とし穴に対して" :
+				"落とし穴の縁に立っている間は");
 #endif /*JP*/
 			    trap_skipped = TRUE;
 			    deal_with_floor_trap = FALSE;
@@ -4169,12 +4169,12 @@ boolean force;
 			case SPIKED_PIT:
 				if (!u.dx && !u.dy) {
 				    You(E_J("are already on the edge of the pit.",
-					    "すでに落し穴の縁にいる。"));
+					    "すでに落とし穴の縁にいる。"));
 				    return 0;
 				}
 				if (!(mtmp = m_at(x,y))) {
 				    pline(E_J("Try filling the pit instead.",
-					      "代わりに、落し穴を埋めてみたら。"));
+					      "代わりに、落とし穴を埋めてみたら。"));
 				    return 0;
 				}
 				return help_monster_out(mtmp, ttmp);

--- a/src/xdat.c
+++ b/src/xdat.c
@@ -386,8 +386,9 @@ wiz_xdat()
 	anything any;
 	struct monst *mtmp;
 	struct obj *otmp;
+	boolean inv;
 
-	switch (yn_function("Check extra data of MONST, or OBJ?", "mo", '\0')) {
+	switch (yn_function("Check extra data of MONST, OBJ or FLOOROBJ?", "mof", '\0')) {
 	    case 'm':
 		w = create_nhwindow(NHW_MENU);
 		start_menu(w);
@@ -414,10 +415,17 @@ wiz_xdat()
 		}
 		break;
 	    case 'o':
+		otmp = invent;
+		inv = TRUE;
+		goto show_objs;
+	    case 'f':
+		otmp = fobj;
+		inv = FALSE;
+show_objs:
 		w = create_nhwindow(NHW_MENU);
 		start_menu(w);
 		cnt = 0;
-		for (otmp = invent; otmp; otmp = otmp->nobj) {
+		for (; otmp; otmp = otmp->nobj) {
 		    if (otmp->oextra) {
 			any.a_obj = otmp;
 			Sprintf(buf, "%s", xname(otmp));
@@ -427,7 +435,8 @@ wiz_xdat()
 		    }
 		}
 		end_menu(w, cnt ? "Pick a object to check:" :
-				  "No object in your inventory has oextra data.");
+			    inv ? "No object in your inventory has oextra data." :
+				  "No object on floor has oextra data.");
 		n = select_menu(w, PICK_ONE, &selected);
 		destroy_nhwindow(w);
 		if (n > 0) {

--- a/src/zap.c
+++ b/src/zap.c
@@ -4448,7 +4448,7 @@ boolean *shopdamage;
 		    if (lev->typ == BOG) {
 			lev->typ = GROUND;
 			filltyp = fillholetyp(x,y);
-			if (filltyp == ROOM) {
+			if (ACCESSIBLE(filltyp)) {
 			    dried = 1;
 			} else {
 			    lev->typ = BOG;
@@ -4456,7 +4456,7 @@ boolean *shopdamage;
 		    } else {
 			lev->typ = ROOM;
 			filltyp = fillholetyp(x,y);
-			if (filltyp == ROOM) {
+			if (ACCESSIBLE(filltyp)) {
 			    ttmp = maketrap(x, y, PIT);
 			    if (ttmp) ttmp->tseen = 1;
 			    dried = 1;


### PR DESCRIPTION
・墓を作る際、石の床だけではなく通路・土の地面・草地・カーペットの床・氷も許す
・墓を暴いて埋めた際、上記の地形に戻す（ただし草→地面、カーペット→床）
・Bonesの死体が無名になっていたのを修正
・Bonesで墓が作られた場合、死体と遺品は埋められる
・Bonesの墓にはフラグを設け、暴いても新たな死体やミイラ・ゾンビを生成したりしない
・表記揺れの統一　落し穴→落とし穴