### PR TITLE
'o'+'.' または 'o'+'>' でlootする

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1654,6 +1654,7 @@ E int FDECL(query_objlist, (const char *, struct obj *, int,
 E struct obj *FDECL(pick_obj, (struct obj *));
 E int NDECL(encumber_msg);
 E int NDECL(doloot);
+E int FDECL(container_at, (int, int, BOOLEAN_P));
 E int FDECL(use_container, (struct obj *,int));
 E int FDECL(loot_mon, (struct monst *,int *,boolean *));
 E const char *FDECL(safe_qbuf, (const char *,unsigned,

--- a/src/lock.c
+++ b/src/lock.c
@@ -643,7 +643,12 @@ doopen()		/* try to open a door */
 
 	if(!get_adjacent_loc((char *)0, (char *)0, u.ux, u.uy, &cc)) return(0);
 
-	if((cc.x == u.ux) && (cc.y == u.uy)) return(0);
+	if((cc.x == u.ux) && (cc.y == u.uy)) {
+	    if (u.dz >= 0 && container_at(cc.x, cc.y, FALSE)) {
+		doloot();
+	    }
+	    return(0);
+	}
 
 	if ((mtmp = m_at(cc.x,cc.y))			&&
 		mtmp->m_ap_type == M_AP_FURNITURE	&&

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -30,7 +30,6 @@ STATIC_DCL long FDECL(mbag_item_gone, (int,struct obj *));
 STATIC_DCL void FDECL(observe_quantum_cat, (struct obj *));
 STATIC_DCL int FDECL(menu_loot, (int, struct obj *, BOOLEAN_P));
 STATIC_DCL int FDECL(in_or_out_menu, (const char *,struct obj *, BOOLEAN_P, BOOLEAN_P));
-STATIC_DCL int FDECL(container_at, (int, int, BOOLEAN_P));
 STATIC_DCL boolean FDECL(able_to_loot, (int, int));
 STATIC_DCL boolean FDECL(mon_beside, (int, int));
 STATIC_DCL void NDECL(del_sokoprize);
@@ -1571,7 +1570,7 @@ encumber_msg()
 }
 
 /* Is there a container at x,y. Optional: return count of containers at x,y */
-STATIC_OVL int
+int
 container_at(x, y, countem)
 int x,y;
 boolean countem;


### PR DESCRIPTION
足元にコンテナがある場合、o)pen + '.' または o)pen + '>' で #loot と同じ動作をする