### PR TITLE
杖・ブレス・魔法で殺されたときの墓碑銘の改善

### DIFF
--- a/include/decl.h
+++ b/include/decl.h
@@ -458,6 +458,7 @@ struct getobj_words {
 struct zapinfo {
 	const char *fltxt;	/* "magic missle", "blast of cold", "burning oil" and etc. */
 	const char *fstxt;	/* "ray", "blast" and etc. */
+	struct monst *zapper;	/* who zapped this */
 	uchar aatyp;		/* AT_BREA:breath, AT_MAGC:spell, AT_NONE:wand */
 	uchar adtyp;		/* AD_MAGM, AD_FIRE... */
 	uchar damn;		/* num of damage dice */
@@ -465,7 +466,8 @@ struct zapinfo {
 	char  oclass;
 	uchar beam_type;	/* for zapglyph; 0-9 */
 	Bitfield(byyou, 1);	/* zapped by you */
-	/* 7 free bits */
+	Bitfield(stdkiller, 1);	/* use generic killer name */
+	/* 6 free bits */
 };
 
 /* extra attachment chunk for obj/mon */

--- a/include/extern.h
+++ b/include/extern.h
@@ -1494,6 +1494,7 @@ E void FDECL(restnames, (int));
 E void FDECL(discover_object, (int,BOOLEAN_P,BOOLEAN_P));
 E void FDECL(undiscover_object, (int));
 E int NDECL(dodiscovered);
+E int NDECL(dodiscovered_group);
 
 /* ### objects.c ### */
 
@@ -2625,7 +2626,7 @@ E struct monst *FDECL(bhitcore, (int,int,int,int,int,int,
 E struct monst *FDECL(boomhit, (int,int,struct obj *));
 E int FDECL(burn_floor_paper, (int,int,BOOLEAN_P,BOOLEAN_P));
 E void FDECL(buzz, (struct zapinfo *,XCHAR_P,XCHAR_P,int,int));
-E void FDECL(buzz_chromatic, (XCHAR_P,XCHAR_P, int, int, int));
+E void FDECL(buzz_chromatic, (struct monst *, int, int, int));
 E void FDECL(melt_ice, (XCHAR_P,XCHAR_P));
 E int FDECL(zap_over_floor, (XCHAR_P,XCHAR_P,struct zapinfo *,boolean *));
 E void FDECL(fracture_rock, (struct obj *));
@@ -2641,8 +2642,8 @@ E void FDECL(damage_resistant_obj, (uchar,int));
 E int FDECL(bresenham_init, (struct bresenham *, int,int,int,int));
 E int FDECL(bresenham_step, (struct bresenham *));
 E void FDECL(bresenham_back, (struct bresenham *));
-E void FDECL(setup_zapinfo, (struct zapinfo *, uchar, uchar, uchar, uchar, const char *, const char *, BOOLEAN_P));
-E void FDECL(setup_zapobj, (struct zapinfo *, struct obj *, boolean));
+E void FDECL(setup_zapinfo, (struct zapinfo *, uchar, uchar, uchar, uchar, const char *, const char *, struct monst *));
+E void FDECL(setup_zapobj, (struct zapinfo *, struct obj *, struct monst *));
 E boolean FDECL(does_obj_worn_out, (struct obj *));
 
 #endif /* !MAKEDEFS_C && !LEV_LEX_C */

--- a/src/apply.c
+++ b/src/apply.c
@@ -3650,7 +3650,7 @@ do_break_wand(obj)
     wanexpl:
 	setup_zapinfo(&zi, AT_EXPL,
 		      (obj->otyp == WAN_DEATH) ? AD_DETH : (obj->otyp - WAN_MAGIC_MISSILE + 1),
-		      1, 1, 0, 0, TRUE);
+		      1, 1, 0, 0, &youmonst);
 	explode(u.ux, u.uy, &zi, dmg, expltype);
 	makeknown(obj->otyp);	/* explode described the effect */
 	goto discard_broken_wand;
@@ -3670,7 +3670,7 @@ do_break_wand(obj)
     }
 
     /* magical explosion and its visual effect occur before specific effects */
-    setup_zapinfo(&zi, AT_EXPL, AD_MAGM, 1, 1, 0, 0, TRUE);
+    setup_zapinfo(&zi, AT_EXPL, AD_MAGM, 1, 1, 0, 0, &youmonst);
     zi.oclass = WAND_CLASS;
     explode(obj->ox, obj->oy, &zi, rnd(dmg), EXPL_MAGICAL);
 
@@ -4159,7 +4159,7 @@ doapply()
 		useup(obj);
 		pline(E_J("As you activate the orb, it explodes!",
 			  "力を引き出そうとしたとたん、オーブは爆発した！"));
-		setup_zapinfo(&zi, AT_EXPL, AD_FIRE, 1, 1, 0, 0, TRUE);
+		setup_zapinfo(&zi, AT_EXPL, AD_FIRE, 1, 1, 0, 0, &youmonst);
 		zi.oclass = WAND_CLASS;
 		explode(u.ux, u.uy, &zi, d(12,6), EXPL_FIERY);
 		break;

--- a/src/explode.c
+++ b/src/explode.c
@@ -699,7 +699,7 @@ splatter_burning_oil(x, y)
     int x, y;
 {
     struct zapinfo zi;
-    setup_zapinfo(&zi, AT_EXPL, AD_FIRE, 1, 1, "”R‚¦‚é–û", 0, TRUE);
+    setup_zapinfo(&zi, AT_EXPL, AD_FIRE, 1, 1, "”R‚¦‚é–û", 0, &youmonst);
     zi.oclass = BURNING_OIL;
     explode(x, y, &zi, d(4,4), EXPL_FIERY);
 }

--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -870,7 +870,7 @@ buzzmu(mtmp, mattk)		/* monster uses spell (ranged) */
 		setup_zapinfo(&zi, AT_MAGC, mattk->adtyp,
 				   mattk->damn, 6,
 				   (const char *)0, (const char *)0, /* use default names */
-				   FALSE);
+				   mtmp);
 		buzz(&zi, mtmp->mx, mtmp->my, /*sgn*/(tbx), /*sgn*/(tby));
 	    } else impossible("Monster spell %d cast", mattk->adtyp-1);
 	}

--- a/src/mon.c
+++ b/src/mon.c
@@ -1662,7 +1662,7 @@ boolean was_swallowed;			/* digestion */
 #endif /*JP*/
 	    	killer = killer_buf;
 	    	killer_format = KILLED_BY_AN;
-		setup_zapinfo(&zi, AT_EXPL, AD_PHYS, 1, 1, killer, 0, FALSE);
+		setup_zapinfo(&zi, AT_EXPL, AD_PHYS, 1, 1, killer, 0, mon);
 		zi.oclass = MON_EXPLODE;
 	    	explode(mon->mx, mon->my, &zi, tmp, EXPL_NOXIOUS); 
 	    	return (FALSE);

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -980,7 +980,7 @@ breamu(mtmp, mattk)			/* monster breathes at you (ranged) */
 			      breathwep[typ-1]);
 		    setup_zapinfo(&zi, AT_BREA, typ, mattk->damn, 6,
 				       (const char *)0, (const char *)0, /* use default names */
-				       FALSE);
+				       mtmp);
 		    buzz(&zi, mtmp->mx, mtmp->my, /*sgn*/(tbx), /*sgn*/(tby));
 		    nomul(0);
 		    /* breath runs out sometimes. Also, give monster some
@@ -995,7 +995,7 @@ breamu(mtmp, mattk)			/* monster breathes at you (ranged) */
 		    /* Chromatic Dragon */
 		    if(canseemon(mtmp))
 			pline(E_J("%s breathes %s!","%sは五色のブレスを吐いた！"), Monnam(mtmp));
-		    buzz_chromatic(mtmp->mx, mtmp->my, tbx, tby, mattk->damn);
+		    buzz_chromatic(mtmp, tbx, tby, mattk->damn);
 		    if(!rn2(3))
 			mtmp->mspec_used = 10+rn2(10);
 		} else impossible("Breath weapon %d used", typ-1);

--- a/src/muse.c
+++ b/src/muse.c
@@ -1271,7 +1271,7 @@ struct monst *mtmp;
 		otmp->spe--;
 		if (oseen) makeknown(otmp->otyp);
 		m_using = TRUE;
-		setup_zapobj(&zi, otmp, FALSE);
+		setup_zapobj(&zi, otmp, mtmp);
 		buzz(&zi, mtmp->mx, mtmp->my,
 			/*sgn*/(mtmp->mux-mtmp->mx), /*sgn*/(mtmp->muy-mtmp->my));
 		m_using = FALSE;
@@ -1287,7 +1287,7 @@ struct monst *mtmp;
 				     "Šp“J‚ª‚«–Â‚ç‚³‚ê‚é‚Ì‚ð"));
 		otmp->spe--;
 		m_using = TRUE;
-		setup_zapobj(&zi, otmp, FALSE);
+		setup_zapobj(&zi, otmp, mtmp);
 		buzz(&zi, mtmp->mx, mtmp->my,
 			/*sgn*/(mtmp->mux-mtmp->mx), /*sgn*/(mtmp->muy-mtmp->my));
 		m_using = FALSE;

--- a/src/music.c
+++ b/src/music.c
@@ -450,7 +450,7 @@ struct obj *instr;
 		    }
 		} else {
 		    struct zapinfo zi;
-		    setup_zapobj(&zi, instr, TRUE);
+		    setup_zapobj(&zi, instr, &youmonst);
 		    buzz(&zi, u.ux, u.uy, u.dx, u.dy);
 		}
 		makeknown(instr->otyp);

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -928,11 +928,11 @@ dobreathe()
 	if (!mattk)
 	    impossible("bad breath attack?");	/* mouthwash needed... */
 	else if (mattk->adtyp == AD_RBRE)
-	    buzz_chromatic(u.ux, u.uy, u.dx, u.dy, mattk->damn);
+	    buzz_chromatic(&youmonst, u.dx, u.dy, mattk->damn);
         else {
 	    setup_zapinfo(&zi, AT_BREA, mattk->adtyp, mattk->damn, 6,
 			       (const char *)0, (const char *)0, /* use default names */
-			       TRUE);
+			       &youmonst);
 	    buzz(&zi, u.ux, u.uy, u.dx, u.dy);
 	}
 	return(1);

--- a/src/potion.c
+++ b/src/potion.c
@@ -2247,7 +2247,7 @@ dodip()
 	    /* Turn off engine before fueling, turn off fuel too :-)  */
 	    if (obj->lamplit || potion->lamplit) {
 		struct zapinfo zi;
-		setup_zapobj(&zi, potion, TRUE);
+		setup_zapobj(&zi, potion, &youmonst);
 		useup(potion);
 		explode(u.ux, u.uy, &zi, d(6,6), EXPL_FIERY);
 		exercise(A_WIS, FALSE);

--- a/src/priest.c
+++ b/src/priest.c
@@ -725,7 +725,7 @@ struct monst *priest;
 
 	setup_zapinfo(&zi, AT_MAGC, AD_ELEC, 6, 6,
 			   (const char *)0, (const char *)0, /* use default names */
-			   FALSE);
+			   (struct monst *)0);
 	buzz(&zi, x, y, sgn(tbx), sgn(tby)); /* bolt of lightning */
 	exercise(A_WIS, FALSE);
 }

--- a/src/read.c
+++ b/src/read.c
@@ -1370,7 +1370,7 @@ register struct obj	*sobj;
 		 */
 		cval = bcsign(sobj);
 		if(!objects[sobj->otyp].oc_name_known) more_experienced(0,10);
-		setup_zapobj(&zi, sobj, TRUE);
+		setup_zapobj(&zi, sobj, &youmonst);
 		useup(sobj);
 		makeknown(SCR_FIRE);
 		if(confused) {

--- a/src/spell.c
+++ b/src/spell.c
@@ -919,7 +919,7 @@ boolean atme;
 			} else {
 			    setup_zapinfo(&zi, AT_EXPL,
 					  pseudo->otyp == SPE_FIREBALL ? AD_FIRE : AD_COLD,
-					  1, 1, 0, 0, TRUE);
+					  1, 1, 0, 0, &youmonst);
 			    zi.oclass = 0;
 			    explode(u.dx, u.dy, &zi, u.ulevel/2 + 1 + spell_damage_bonus(),
 					(pseudo->otyp == SPE_CONE_OF_COLD) ?

--- a/src/tech.c
+++ b/src/tech.c
@@ -1609,7 +1609,7 @@ struct obj *obj;
 
 	case SCR_FIRE: {
 	    struct zapinfo zi;
-	    setup_zapobj(&zi, obj, TRUE);
+	    setup_zapobj(&zi, obj, &youmonst);
 	    explode(mon->mx, mon->my, &zi, (2*(rn1(3, 3) + 2 * bcsign(obj)) + 1), EXPL_FIERY);
 	    makeknown(SCR_FIRE);
 	    nohap = FALSE;
@@ -1674,7 +1674,7 @@ struct obj *obj;
 	    int oldhp = mon->mhp;
 	    setup_zapinfo(&zi, AT_MAGC, AD_DETH, 1, 1,
 			  E_J("lethal power","’vŽ€‚Ì–‚—Í"),
-			  E_J("power","–‚—Í"), TRUE);
+			  E_J("power","–‚—Í"), &youmonst);
 	    zhitm(mon, &zi, &otmp);
 	    if (mon->mhp < oldhp) {
 		xkilled(mon, 1);

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -1520,7 +1520,7 @@ do_storms()
 	    if(dirx != 0 || diry != 0)
 		setup_zapinfo(&zi, AT_MAGC, AD_ELEC, 8, 6,
 				   (const char *)0, (const char *)0, /* use default names */
-				   FALSE);
+				   (struct monst *)0);
 		buzz(&zi, x, y, dirx, diry);
 	}
     }


### PR DESCRIPTION
杖・ブレス・魔法で殺されたときの墓碑銘に、下手人の怪物名を表記するようにした