### PR TITLE
Fix chameleon bug

### DIFF
--- a/dat/dungeon.def
+++ b/dat/dungeon.def
@@ -24,7 +24,7 @@ CHAINBRANCH:	"Sokoban" "oracle" + (1, 0) up
 RNDLEVEL:	"bigrm" "B" @ (10, 3) 40 5
 CHAINBRANCH:	"The Quest" "oracle" + (6, 2) portal
 BRANCH:		"Fort Ludios" @ (18, 4) portal
-RNDLEVEL:	"medusa" "none" @ (-4, 3) 2
+RNDLEVEL:	"medusa" "none" @ (-4, 3) 4
 LEVALIGN:	chaotic
 LEVEL:		"castle" "none" @ (-1, 0)
 #LEVEL:		"castle" "none" @ (-2, 0)

--- a/dat/medusa.des
+++ b/dat/medusa.des
@@ -215,3 +215,253 @@ MONSTER:random,random,random
 MONSTER:random,random,random
 MONSTER:random,random,random
 MONSTER:random,random,random
+
+MAZE:"medusa-3",' '
+FLAGS: noteleport,shortsighted
+GEOMETRY:center,center
+#
+# Here you disturb ravens nesting in the trees.
+#
+MAP
+}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}
+}}}}}}}}}}.}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}.}}}}}}}}}}}}}}}}}}}}}}}}}}}}
+}}}}}}}}T..T.}}}}}}}}}}}}}}}}}}}}..}}}}}}}}.}}}...}}}}}}}.}}}}}......}}}}}}}
+}}}}}}.......T.}}}}}}}}}}}..}}}}..T.}}}}}}...T...T..}}...T..}}..-----..}}}}}
+}}}...-----....}}}}}}}}}}.T..}}}}}...}}}}}.....T..}}}}}......T..|...|.T..}}}
+}}}.T.|...|...T.}}}}}}}.T......}}}}..T..}}.}}}.}}...}}}}}.T.....+...|...}}}}
+}}}}..|...|.}}.}}}}}.....}}}T.}}}}.....}}}}}}.T}}}}}}}}}}}}}..T.|...|.}}}}}}
+}}}}}.|...|.}}}}}}..T..}}}}}}}}}}}}}T.}}}}}}}}..}}}}}}}}}}}.....-----.}}}}}}
+}}}}}.--+--..}}}}}}...}}}}}}}}}}}}}}}}}}}T.}}}}}}}}}}}}}}}}.T.}........}}}}}
+}}}}}.......}}}}}}..}}}}}}}}}.}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}.}}}.}}.T.}}}}}}
+}}.T...T...}}}}T}}}}}}}}}}}....}}}}}}}}}}T}}}}}.T}}...}}}}}}}}}}}}}}...}}}}}
+}}}...T}}}}}}}..}}}}}}}}}}}.T...}}}}}}}}.T.}.T.....T....}}}}}}}}}}}}}.}}}}}}
+}}}}}}}}}}}}}}}....}}}}}}}...}}.}}}}}}}}}}............T..}}}}}.T.}}}}}}}}}}}
+}}}}}}}}}}}}}}}}..T..}}}}}}}}}}}}}}..}}}}}..------+--...T.}}}....}}}}}}}}}}}
+}}}}.}..}}}}}}}.T.....}}}}}}}}}}}..T.}}}}.T.|...|...|....}}}}}.}}}}}...}}}}}
+}}}.T.}...}..}}}}T.T.}}}}}}.}}}}}}}....}}...|...+...|.}}}}}}}}}}}}}..T...}}}
+}}}}..}}}.....}}...}}}}}}}...}}}}}}}}}}}}}T.|...|...|}}}}}}}}}}}....T..}}}}}
+}}}}}..}}}.T..}}}.}}}}}}}}.T..}}}}}}}}}}}}}}---S-----}}}}}}}}}}}}}....}}}}}}
+}}}}}}}}}}}..}}}}}}}}}}}}}}}.}}}}}}}}}}}}}}}}}T..T}}}}}}}}}}}}}}}}}}}}}}}}}}
+}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}
+ENDMAP
+RANDOM_PLACES:(08,06),(66,05),(46,15)
+REGION:(00,00,74,19),lit,"ordinary"
+REGION:(49,14,51,16),random,"ordinary",unfilled
+REGION:(07,05,09,07),unlit,"ordinary"
+REGION:(65,04,67,06),unlit,"ordinary"
+REGION:(45,14,47,16),unlit,"ordinary"
+# Non diggable walls
+# 4th room has diggable walls as Medusa is never placed there
+NON_DIGGABLE:(06,04,10,08)
+NON_DIGGABLE:(64,03,68,07)
+NON_DIGGABLE:(44,13,48,17)
+# All places are accessible also with jumping, so don't bother
+# restricting the placement when teleporting from levels below this.
+TELEPORT_REGION:(33,02,38,07),(0,0,0,0),down
+STAIR:(32,01,39,07),(0,0,0,0),up
+STAIR:place[0],down
+DOOR:locked,(08,08)
+DOOR:locked,(64,05)
+DOOR:random,(50,13)
+DOOR:locked,(48,15)
+# 
+FOUNTAIN:place[1]
+#
+#CONTAINER:'`',"statue",place[2],uncursed,"knight",3,"Perseus"
+CONTAINER:'`',"statue",place[2],uncursed,"knight",3,"ペルセウス"
+OBJECT[75%]:'[',"shield of reflection",contained,cursed,+0
+OBJECT[25%]:'[',"levitation boots",contained,random,+0
+OBJECT[50%]:')',"scimitar",contained,blessed,+2
+OBJECT[50%]:'(',"sack",contained
+
+#
+CONTAINER:'`',"statue",random
+CONTAINER:'`',"statue",random
+CONTAINER:'`',"statue",random
+CONTAINER:'`',"statue",random
+CONTAINER:'`',"statue",random
+CONTAINER:'`',"statue",random
+CONTAINER:'`',"statue",random
+OBJECT:random,random,random
+OBJECT:random,random,random
+OBJECT:random,random,random
+OBJECT:random,random,random
+OBJECT:random,random,random
+OBJECT:random,random,random
+OBJECT:random,random,random
+OBJECT:random,random,random
+OBJECT:'?',"blank paper",(48,18)
+OBJECT:'?',"blank paper",(48,18)
+#
+TRAP:"rust",random
+TRAP:"rust",random
+TRAP:"board",random
+TRAP:"board",random
+TRAP:random,random
+#
+MONSTER:'@',"Medusa",place[0]
+MONSTER:';',"giant eel",random
+MONSTER:';',"giant eel",random
+MONSTER:';',"jellyfish",random
+MONSTER:';',"jellyfish",random
+MONSTER:'n',"wood nymph",random
+MONSTER:'n',"wood nymph",random
+MONSTER:'n',"water nymph",random
+MONSTER:'n',"water nymph",random
+
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+MONSTER:'B',"raven",random,hostile
+
+
+MAZE:"medusa-4",' '
+FLAGS: noteleport
+GEOMETRY:center,center
+#
+# Here the Medusa rules some slithery monsters from her 'palace', with
+# a yellow dragon nesting in the backyard.
+#
+MAP
+}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}
+}}}}}}}}}}}}}}........}}}}}}}}}}}}}}}}}}}}}}}..}}}.....}}}}}}}}}}}----|}}}}}
+}}}}}}..----------F-.....}}}}}}}}}}}}}}}}..---...}}}}....T.}}}}}}}....|}}}}}
+}}}.....|...F......S}}}}....}}}}}}}...}}.....|}}.}}}}}}}......}}}}|......}}}
+}}}.....+...|..{...|}}}}}}}}}}}}.....}}}}|...|}}}}}}}}}}}.}}}}}}}}----.}}}}}
+}}......|...|......|}}}}}}}}}......}}}}}}|.......}}}}}}}}}}}}}..}}}}}...}}}}
+}}|-+--F|-+--....|F|-|}}}}}....}}}....}}}-----}}.....}}}}}}}......}}}}.}}}}}
+}}|...}}|...|....|}}}|}}}}}}}..}}}}}}}}}}}}}}}}}}}}....}}}}}}}}....T.}}}}}}}
+}}|...}}F...+....F}}}}}}}..}}}}}}}}}}}}}}...}}}}}}}}}}}}}}}}}}}}}}....}}..}}
+}}|...}}|...|....|}}}|}....}}}}}}....}}}...}}}}}...}}}}}}}}}}}}}}}}}.....}}}
+}}--+--F|-+--....-F|-|....}}}}}}}}}}.T...}}}}....---}}}}}}}}}}}}}}}}}}}}}}}}
+}}......|...|......|}}}}}.}}}}}}}}}....}}}}}}}.....|}}}}}}}}}.}}}}}}}}}}}}}}
+}}}}....+...|..{...|.}}}}}}}}}}}}}}}}}}}}}}}}}}.|..|}}}}}}}......}}}}...}}}}
+}}}}}}..|...F......|...}}}}}}}}}}..---}}}}}}}}}}--.-}}}}}....}}}}}}....}}}}}
+}}}}}}}}-----S----F|....}}}}}}}}}|...|}}}}}}}}}}}}...}}}}}}...}}}}}}..}}}}}}
+}}}}}}}}}..............T...}}}}}.|.......}}}}}}}}}}}}}}..}...}.}}}}....}}}}}
+}}}}}}}}}}....}}}}...}...}}}}}.......|.}}}}}}}}}}}}}}.......}}}}}}}}}...}}}}
+}}}}}}}}}}..}}}}}}}}}}.}}}}}}}}}}-..--.}}}}}}}}..}}}}}}..T...}}}..}}}}}}}}}}
+}}}}}}}}}...}}}}}}}}}}}}}}}}}}}}}}}...}}}}}}}....}}}}}}}.}}}..}}}...}}}}}}}}
+}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}.}}}}}}....}}}}}}}}}}}}}}}}}}}...}}}}}}
+}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}
+ENDMAP
+#
+RANDOM_PLACES:(04,08),(10,04),(10,08),(10,12)
+#
+REGION:(00,00,74,19),lit,"ordinary"
+REGION:(13,03,18,13),lit,"ordinary",unfilled
+#
+TELEPORT_REGION:(64,01,74,17),(0,0,0,0),down
+TELEPORT_REGION:(02,02,18,13),(0,0,0,0),up
+#
+STAIR:(67,01,74,20),(0,0,0,0),up
+STAIR:place[0],down
+#
+DOOR:locked,(04,06)
+DOOR:locked,(04,10)
+DOOR:locked,(08,04)
+DOOR:locked,(08,12)
+DOOR:locked,(10,06)
+DOOR:locked,(10,10)
+DOOR:locked,(12,08)
+#
+BRANCH:levregion(27,00,79,20),(0,0,0,0)
+#
+NON_DIGGABLE:(01,01,22,14)
+#
+OBJECT:'(',"crystal ball",(07,08)
+#
+#CONTAINER:'`',"statue",place[2],uncursed,"knight",3,"Perseus"
+CONTAINER:'`',"statue",place[2],uncursed,"knight",3,"ペルセウス"
+OBJECT[75%]:'[',"shield of reflection",contained,cursed,+0
+OBJECT[25%]:'[',"levitation boots",contained,random,+0
+OBJECT[50%]:')',"scimitar",contained,blessed,+2
+OBJECT[50%]:'(',"sack",contained
+#
+CONTAINER:'`',"statue",random
+CONTAINER:'`',"statue",random
+CONTAINER:'`',"statue",random
+CONTAINER:'`',"statue",random
+CONTAINER:'`',"statue",random
+CONTAINER:'`',"statue",random
+CONTAINER:'`',"statue",random
+OBJECT:random,random,random
+OBJECT:random,random,random
+OBJECT:random,random,random
+OBJECT:random,random,random
+OBJECT:random,random,random
+OBJECT:random,random,random
+OBJECT:random,random,random
+OBJECT:random,random,random
+#
+TRAP:random,random
+TRAP:random,random
+TRAP:random,random
+TRAP:random,random
+TRAP:random,random
+TRAP:random,random
+TRAP:random,random
+#
+MONSTER:'@',"Medusa",place[0]
+MONSTER:';',"kraken",(07,07)
+#
+# the nesting dragon
+MONSTER:'D',"yellow dragon",(05,04),asleep
+MONSTER[50%]:'D',"baby yellow dragon",(04,04),asleep
+MONSTER[25%]:'D',"baby yellow dragon",(04,05),asleep
+OBJECT:'%',"egg",(05,04),"yellow dragon",random
+OBJECT[50%]:'%',"egg",(05,04),"yellow dragon",random
+OBJECT[25%]:'%',"egg",(05,04),"yellow dragon",random
+#
+MONSTER:';',"giant eel",random
+MONSTER:';',"giant eel",random
+MONSTER:';',"jellyfish",random
+MONSTER:';',"jellyfish",random
+MONSTER:'S',random,random
+MONSTER:'S',random,random
+MONSTER:'S',random,random
+MONSTER:'S',random,random
+MONSTER:'S',random,random
+MONSTER:'S',random,random
+MONSTER:'S',random,random
+MONSTER:'S',random,random
+MONSTER:'S',random,random
+MONSTER:'S',random,random
+MONSTER:'S',random,random
+MONSTER:'S',random,random
+MONSTER:'S',random,random
+MONSTER:'S',random,random
+MONSTER:'N',"black naga hatchling",random
+MONSTER:'N',"black naga hatchling",random
+MONSTER:'N',"black naga hatchling",random
+MONSTER:'N',"black naga hatchling",random
+MONSTER:'N',"black naga",random
+MONSTER:'N',"black naga",random
+MONSTER:'N',"black naga",random
+MONSTER:'N',"black naga",random

--- a/dat/mines.des
+++ b/dat/mines.des
@@ -344,69 +344,55 @@ RANDOM_CORRIDORS
 LEVEL: "minetn-4"
 ROOM: "ordinary",lit,(3,3),(center,center),(30,15)
 NAME: "town"
-FOUNTAIN:(08,07)
-FOUNTAIN:(18,07)
+FOUNTAIN:(07,07)
+FOUNTAIN:(17,07)
 MONSTER: '@', "watchman", random, peaceful
 MONSTER: '@', "watchman", random, peaceful
 MONSTER: '@', "watchman", random, peaceful
 MONSTER: '@', "watchman", random, peaceful
 MONSTER: '@', "watch captain", random, peaceful
 
-SUBROOM:"book shop",lit,(4,2),(3,3),"town"
+SUBROOM:"book shop",lit,(3,2),(3,3),"town"
 DOOR: false,closed,south,random
 
-SUBROOM:"ordinary",random,(8,2),(2,2),"town"
+SUBROOM:"ordinary",random,(7,2),(2,2),"town"
 DOOR: false,closed,south,random
 
-SUBROOM:"temple",lit,(11,3),(5,4),"town"
+SUBROOM:"temple",lit,(10,3),(5,4),"town"
 DOOR: false,closed,south,random
 ALTAR:(2,1),align[0],shrine
 MONSTER: 'G', "gnomish wizard", random
 MONSTER: 'G', "gnomish wizard", random
 
-#SUBROOM:"ordinary",random,(19,2),(2,2),"town"
-#DOOR: false,closed,south,random
-#MONSTER: 'G', random, random
-SUBROOM:"wand shop",random,(19,2),(2,2),"town"
+SUBROOM:"wand shop",random,(18,2),(2,2),"town"
 DOOR: false,closed,south,random
 
-SUBROOM:"candle shop",lit,(22,2),(3,3),"town"
+SUBROOM:"candle shop",lit,(21,2),(3,3),"town"
 DOOR:false,closed,south,random
 
-#SUBROOM:"ordinary",random,(26,2),(2,2),"town"
-#DOOR:false,locked,east,random
-#MONSTER: 'G',random,random
-SUBROOM:"ring shop",random,(26,2),(2,2),"town"
+SUBROOM:"ring shop",random,(25,2),(3,2),"town"
 DOOR:false,closed,east,random
 
-SUBROOM:"tool shop",lit,(4,10),(3,3),"town"
-#CHANCE:90
+SUBROOM:"tool shop",lit,(3,10),(3,3),"town"
 DOOR:false,closed,north,random
 
-SUBROOM:"ordinary",random,(8,11),(2,2),"town"
+SUBROOM:"ordinary",random,(7,11),(2,2),"town"
 DOOR:false,locked,south,random
 MONSTER: 'k',"kobold shaman",random
 MONSTER: 'k',"kobold shaman",random
 MONSTER: 'f',"kitten",random
 MONSTER: 'f',random,random
 
-SUBROOM:"food shop",lit,(11,11),(3,2),"town"
-#CHANCE:90
+SUBROOM:"food shop",lit,(10,11),(3,2),"town"
 DOOR:false,closed,east,random
 
-#SUBROOM:"ordinary",random,(17,11),(2,2),"town"
-#DOOR:false,closed,west,random
-SUBROOM:"armor shop",random,(17,11),(2,2),"town"
+SUBROOM:"armor shop",random,(16,11),(3,2),"town"
 DOOR:false,closed,west,random
 
-#SUBROOM:"ordinary",random,(20,10),(2,2),"town"
-#DOOR:false,locked,north,random
-#MONSTER:'G',random,random
-SUBROOM:"weapon shop",random,(20,10),(2,2),"town"
+SUBROOM:"weapon shop",random,(20,10),(3,2),"town"
 DOOR:false,closed,north,random
 
-SUBROOM:"shop",lit,(23,10),(3,3),"town"
-#CHANCE:90
+SUBROOM:"shop",lit,(24,10),(3,3),"town"
 DOOR:false,closed,north,random
 
 ROOM: "ordinary" , random, random, random, random
@@ -420,9 +406,11 @@ MONSTER: 'G', "gnome", random
 
 ROOM: "ordinary" , random, random, random, random
 MONSTER: 'h', "dwarf", random
+MONSTER: 'G', "gnome", random
 
 ROOM: "ordinary" , random, random, random, random
 TRAP: random, random
+MONSTER: 'G', "gnome", random
 MONSTER: 'G', "gnome", random
 
 RANDOM_CORRIDORS

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -424,8 +424,8 @@ once_per_player_input_things()
 	    if(!is_lava(u.ux,u.uy))
 		u.utrap = 0;
 	    else if (!u.uinvulnerable) {
-		u.utrap -= 1<<8;
-		if(u.utrap < 1<<8) {
+		u.utrap -= (1<<8);
+		if(u.utrap < (1<<8)) {
 		    killer_format = KILLED_BY;
 		    killer = E_J("molten lava","Ï‚¦‚½‚¬‚é—nŠâ‚É’¾‚İ");
 		    You(E_J("sink below the surface and die.",

--- a/src/apply.c
+++ b/src/apply.c
@@ -1141,6 +1141,20 @@ struct obj **optr;
 			  "ごめんなさい、水と火は相容れないんです。"));
 		return;
 	}
+	if(obj->oerodeproof) {
+#ifndef JP
+		pline_The("%s %sn't ignite.", s, (obj->quan > 1) ? "do" : "does");
+#else
+		pline("%sこのろうそくには火がつかない%s",
+			(obj->rknown) ? "" : "どういうわけか、",
+			(obj->rknown) ? "。" : "！");
+#endif /*JP*/
+		if (!obj->rknown) {
+		    obj->rknown = 1;
+		    update_inventory();
+		}
+		return;
+	}
 
 	otmp = carrying(CANDELABRUM_OF_INVOCATION);
 	if(!otmp || otmp->spe == 7) {

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -43,6 +43,7 @@ const struct innate {
 
 	bar_abil[] = { {	 1, &(HPoison_resistance), "", "" },
 		     {   7, &(HFast), E_J("quick","r•q‚É‚È‚Á‚½"), E_J("slow","r•q‚³‚ğ¸‚Á‚½") },
+		     {  10, &(HKnow_enchantment), E_J("discerning","–Ú—˜‚«‚É‚È‚Á‚½"), E_J("unselective","ŠÓ’èŠá‚ğ¸‚Á‚½") },
 		     {  15, &(HStealth), E_J("stealthy","r‰B–§«‚Í‚‚Ü‚Á‚½"), E_J("","r‰B–§«‚Í’á‚­‚È‚Á‚½") },
 		     {	 0, 0, 0, 0 } },
 

--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -1132,17 +1132,6 @@ boolean gone;
 		/* Make invisible monsters go away */
 		if (see_invis_off())
 		    makeknown(RIN_SEE_INVISIBLE);
-//		if (!See_invisible) {
-//		    set_mimic_blocking(); /* do special mimic handling */
-//		    see_monsters();
-//		}
-//
-//		if (Invisible && !Blind) {
-//		    newsym(u.ux,u.uy);
-//		    pline(E_J("Suddenly you cannot see yourself.",
-//			      "ìÀëRÅAÇ†Ç»ÇΩÇÕé©ï™Ç™å©Ç¶Ç»Ç≠Ç»Ç¡ÇΩÅB"));
-//		    makeknown(RIN_SEE_INVISIBLE);
-//		}
 		break;
 	case RIN_INVISIBILITY:
 		if (!Invis && !BInvis && !Blind) {
@@ -1196,8 +1185,10 @@ boolean gone;
 		/* If you're no longer protected, let the chameleons
 		 * change shape again -dgk
 		 */
-		if (restartcham())
-		    makeknown(RIN_PROTECTION_FROM_SHAPE_CHAN);
+		if (!Protection_from_shape_changers) {
+		    if (restartcham())
+			makeknown(RIN_PROTECTION_FROM_SHAPE_CHAN);
+		}
 		break;
     }
 }
@@ -1310,8 +1301,10 @@ register struct obj *otmp;
 		    makeknown(GLASSES_OF_TRUE_SIGHT);
 		EProtection_from_shape_changers &= ~W_TOOL;
 		ESearching                      &= ~W_TOOL;
-		if (restartcham())
-		    makeknown(GLASSES_OF_TRUE_SIGHT);
+		if (!Protection_from_shape_changers) {
+		    if (restartcham())
+			makeknown(GLASSES_OF_TRUE_SIGHT);
+		}
 		return;
 	    } else
 		see_monsters();

--- a/src/dog.c
+++ b/src/dog.c
@@ -258,6 +258,10 @@ boolean with_you;
 	    /* tail segs are not yet initialized or displayed */
 	} else mtmp->wormno = 0;
 
+	/* update shape-changers in case protection against
+	   them is different now than when the level was saved */
+	restore_cham(mtmp);
+
 	/* some monsters might need to do something special upon arrival
 	   _after_ the current level has been fully set up; see dochug() */
 	mtmp->mstrategy |= STRAT_ARRIVE;

--- a/src/fountain.c
+++ b/src/fountain.c
@@ -399,6 +399,7 @@ register struct obj *obj;
 			obj->oerodeproof = FALSE;
 			exercise(A_WIS, FALSE);
 		} else {
+			int oldmat;
 			/* The lady of the lake acts! - Eric Backus */
 			/* Be *REAL* nice */
 	  pline(E_J("From the murky depths, a hand reaches up to bless the sword.",
@@ -406,7 +407,9 @@ register struct obj *obj;
 			pline(E_J("As the hand retreats, the fountain disappears!",
 				  "Žè‚ª‘Þ‚­‚ÆAò‚ÍÁ‚¦Ž¸‚¹‚½I"));
 			/*obj = oname(obj, artiname(ART_EXCALIBUR));*/
+			oldmat = obj->madeof;
 			create_artifact(obj, ART_EXCALIBUR);
+			if (oldmat) change_material(obj, oldmat);
 			discover_artifact(ART_EXCALIBUR);
 			bless(obj);
 			obj->oeroded = obj->oeroded2 = 0;

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -1055,6 +1055,7 @@ const struct probmat primitive_weapon_probs1[] = {
 const struct probmat silver_weapon_probs0[] = {
 { 900, SILVER	},
 { 100, IRON	},
+{   0, MITHRIL	},
 {   0, 0	} /* terminator */
 };
 
@@ -1063,22 +1064,25 @@ const struct probmat silver_weapon_probs1[] = {
 { 810, IRON	},
 { 180, SILVER	},
 {  10, METAL	},
+{   0, MITHRIL	},
 {   0, 0	} /* terminator */
 };
 
 /* silver weapon(middle prob) */
 const struct probmat silver_weapon_probs2[] = {
-{ 900, IRON	},
+{ 899, IRON	},
 {  90, SILVER	},
 {  10, METAL	},
+{   1, MITHRIL	},
 {   0, 0	} /* terminator */
 };
 
 /* silver weapon(low prob) */
 const struct probmat silver_weapon_probs3[] = {
-{ 960, IRON	},
+{ 959, IRON	},
 {  35, SILVER	},
 {   5, METAL	},
+{   1, MITHRIL	},
 {   0, 0	} /* terminator */
 };
 

--- a/src/mon.c
+++ b/src/mon.c
@@ -2523,14 +2523,15 @@ restartcham()
 	int cnt = 0;
 
 	for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
-		if (DEADMONSTER(mtmp)) continue;
+	    if (DEADMONSTER(mtmp)) continue;
+	    if (!mtmp->mcan)
 		mtmp->cham = pm_to_cham(monsndx(mtmp->data));
-		if (mtmp->data->mlet == S_MIMIC && mtmp->msleeping &&
-				cansee(mtmp->mx, mtmp->my)) {
-			set_mimic_sym(mtmp);
-			newsym(mtmp->mx,mtmp->my);
-			cnt++;
-		}
+	    if (mtmp->data->mlet == S_MIMIC && mtmp->msleeping &&
+		cansee(mtmp->mx, mtmp->my)) {
+		set_mimic_sym(mtmp);
+		newsym(mtmp->mx,mtmp->my);
+		cnt++;
+	    }
 	}
 	return cnt;
 }

--- a/src/pray.c
+++ b/src/pray.c
@@ -911,10 +911,13 @@ gcrownu()
 	if (class_gift != STRANGE_OBJECT) {
 	    ;		/* already got bonus above */
 	} else if (obj && obj->otyp == LONG_SWORD && !obj->oartifact) {
+	    int oldmat;
 	    if (!Blind)
 		Your(E_J("sword shines brightly for a moment.",
 			 "Œ•‚Íˆêu‚Ü‚Ô‚µ‚­‹P‚¢‚½B"));
+	    oldmat = obj->madeof;
 	    create_artifact(obj, ART_EXCALIBUR);
+	    if (oldmat) change_material(obj, oldmat);
 	    if (obj && obj->oartifact == ART_EXCALIBUR) u.ugifts++;
 	}
 	/* acquire Excalibur's skill regardless of weapon or gift */

--- a/src/role.c
+++ b/src/role.c
@@ -283,7 +283,7 @@ const struct Role roles[] = {
 	/* Init   Lower  Higher */
 	{ 13, 0,  0, 8,  1, 0 },        /* Hit points */
 	{  4, 3,  0, 2,  0, 2 },10,     /* Energy */
-	10, 9, 2, 1, 10, A_DEX, SPE_REMOVE_CURSE,   -4
+	10, 7, -2, 2, 10, A_INT, SPE_REMOVE_CURSE,   -4
 },
 /*	ローマ・カトリック教会の階層組織
 	教皇 > 枢機卿 > 大司教 > 司教 > 司祭 > 助祭

--- a/src/shknam.c
+++ b/src/shknam.c
@@ -233,15 +233,18 @@ const struct shassortment tailorshop_assortment[] = {
 	{ 6, -DUNCE_CAP			}, { 5, -KATYUSHA		},
 	{ 4, -NURSE_CAP			}, { 7, -LEATHER_JACKET		},
 	{ 4, -MAID_DRESS		}, { 4, -NURSE_UNIFORM		},
-	{10, -ROBE			}, { 2, -ROBE_OF_PROTECTION	},
+	{ 5, -ROBE			}, { 2, -ROBE_OF_PROTECTION	},
 	{ 2, -ROBE_OF_POWER		}, { 5, -ROBE_OF_WEAKNESS	},
-	{10, -HAWAIIAN_SHIRT		}, { 7, -T_SHIRT		},
-	{ 7, -ELVEN_CLOAK		}, { 5, -DWARVISH_CLOAK		},
+	{ 7, -HAWAIIAN_SHIRT		}, { 7, -T_SHIRT		},
+	{ 5, -ELVEN_CLOAK		}, { 5, -DWARVISH_CLOAK		},
 	{ 5, -OILSKIN_CLOAK		}, { 5, -KITCHEN_APRON		},
 	{ 5, -FRILLED_APRON		}, { 5, -ALCHEMY_SMOCK		},
 	{ 5, -LEATHER_CLOAK		}, { 3, -CLOAK_OF_PROTECTION	},
 	{ 4, -CLOAK_OF_INVISIBILITY	}, { 3, -CLOAK_OF_MAGIC_RESISTANCE },
-	{ 3, -CLOAK_OF_DISPLACEMENT	}, {0, 0}
+	{ 3, -CLOAK_OF_DISPLACEMENT	}, { 2, -GLASSES_OF_MAGIC_READING },
+	{ 2, -GLASSES_OF_GAZE_PROTECTION}, { 2, -GLASSES_OF_KNOW_ENCHANTMENT },
+	{ 2, -GLASSES_OF_TRUE_SIGHT	}, { 2, -GLASSES_OF_PHANTASMAGORIA },
+	{ 0, 0 }
 };
 
 const struct shclass shtypes[] = {

--- a/src/spell.c
+++ b/src/spell.c
@@ -1319,7 +1319,9 @@ int spell;
 	 * in that spell type.
 	 */
 	skill = P_SKILL(spell_skilltype(spellid(spell)));
-	difficulty= (spellev(spell)-1) * 4 - ((skill / 10) + (u.ulevel/10/*3*/) + 1);
+	difficulty = (spellev(spell)-1) * 4 - ((u.ulevel/3) + 1);
+	difficulty -= (skill >= 50) ? ((skill - 50) * 12 / 50 + 6) :
+				      (skill * 6 / 50);
 
 	if (difficulty > 0) {
 		/* Player is too low level or unskilled. */

--- a/util/makedefs.c
+++ b/util/makedefs.c
@@ -1067,6 +1067,7 @@ h_filter(line)
 }
 
 static const char *special_oracle[] = {
+#ifndef JP
 	"\"...it is rather disconcerting to be confronted with the",
 	"following theorem from [Baker, Gill, and Solovay, 1975].",
 	"",
@@ -1077,6 +1078,18 @@ static const char *special_oracle[] = {
 	"This provides impressive evidence that the techniques that are",
 	"currently available will not suffice for proving that P != NP or          ",
 	"that P == NP.\"  [Garey and Johnson, p. 185.]"
+#else
+	"「次の定理[Baker, Gill, and Solovay, 1975]に直面することは",
+	"　むしろ困惑することである．",
+	"",
+	"　定理 7.18 次のような再帰的言語 A，Bが存在する",
+	"　　(1)  P(A) == NP(A)，かつ",
+	"　　(2)  P(B) != NP(B)",
+	"",
+	"　これは現在 P != NPであるかまたは P == NPであるかを証明する",
+	"　有効な手法がないことを強く示している．」",
+	"[Garey and Johnson, p. 185.]"
+#endif
 };
 
 /*


### PR DESCRIPTION
・泉および称号獲得でエクスカリバーを得た場合、元のロングソードの素材が銀・ミスリルならそのままの素材を保つ
・燃えないろうそくには火がつかない
・NetHack 3.6から medusa-3, medusa-4 のマップを移植
・カメレオンなどの変身怪物が未踏の階へ移動し、変身怪物封じの能力が異なる状態でプレイヤーがその階へ移動したとき、怪物の状態がおかしくなるバグの修正
・複数のソースから変身怪物封じの能力を得ている状態で、1つを解除しただけで変身怪物が再度変身してしまうバグの修正
・未訳だったデルファイの特別な高位の神託を、JNetHackから移植した